### PR TITLE
Use HTTPS endpoint for Congress API

### DIFF
--- a/sunlight/services/congress.py
+++ b/sunlight/services/congress.py
@@ -14,7 +14,7 @@ from sunlight.service import EntityDict
 import json
 
 
-API_ROOT = "http://congress.api.sunlightfoundation.com"
+API_ROOT = "https://congress.api.sunlightfoundation.com"
 
 LEGISLATOR_ID_TYPES = (
     'bioguide',


### PR DESCRIPTION
This uses the HTTPS endpoint for the Congress API instead of the normal HTTP endpoint.

Putting this out for review before merging, in case there are possible problems with this.

I could add an option to prefer the HTTP endpoint, if people thought that was necessary. (I don't see why it would be, offhand.)
