### PR TITLE
Commented out strange list/map function that was messing up url string

### DIFF
--- a/sunlight/service.py
+++ b/sunlight/service.py
@@ -73,7 +73,7 @@ class Service:
                 " to register for a key."
             )
 
-        top_level_object = list(map(quote, top_level_object))
+       # top_level_object = list(map(quote, top_level_object))
         url = self._get_url(top_level_object, sunlight.config.API_KEY,
                             **kwargs)
         try:


### PR DESCRIPTION
Not sure what the point of this line was, but I had to comment it out to get most of the methods in the congress library working.  I'm guessing it was supposed to pull apart and recode certain method names that weren't convertible to well-formatted URL string parameters.  In which case you may just need to take top_level_object and mash the list back together.  In any case, if you give me info on what was error was being prevented by that list(map(..) method, I'd be happy to try and fix it.
