### PR TITLE
PagingService result limit

### DIFF
--- a/sunlight/pagination.py
+++ b/sunlight/pagination.py
@@ -72,7 +72,7 @@ class PagingService(object):
 
                     if not resp:
                         logger.debug('!   %s returned 0 results this iteration, stopping' % name)
-                        stopthepresses = True
+                        break
 
                     for rec in resp:
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,47 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from sunlight.pagination import PagingService
+from sunlight.services.congress import Congress
+from sunlight.services.opencivic import OpenCivic
+
+
+class TestPagingService(unittest.TestCase):
+    def setUp(self):
+        self.congress = Congress()
+        self.paginator = PagingService(self.congress)
+
+    def test_non_pageable_service(self):
+        """Services that are not pageable should result in an exception being
+        raised when instantiating the PagingService.
+
+        """
+        with self.assertRaises(ValueError):
+            PagingService(OpenCivic())
+
+    def test_paging_past_end(self):
+        """Test that requesting a page past the end of the possible results 
+        will return a generator of length 0, instead of raising an exception.
+
+        """
+        kwargs = {
+            'chamber': 'senate',
+            'page': 1000
+        }
+        self.assertEqual(0, len(list(self.paginator.legislators(**kwargs))))
+
+    def test_limit_too_high(self):
+        """When setting the limit too high on a request, it should return only
+        as many results as exist.
+
+        """
+        kwargs = {
+            'chamber': 'senate',
+            'limit': 101
+        }
+        self.assertEqual(100, len(list(self.paginator.legislators(**kwargs))))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Specifying a result limit, or page number that exceeds the result set returned will no longer throw an exception.  This attempts to address #18.
